### PR TITLE
perf: avoid fetching enum variants

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -313,7 +313,7 @@ pub enum Kind {
     /// A simple type like `VARCHAR` or `INTEGER`.
     Simple,
     /// An enumerated type along with its variants.
-    Enum(Vec<String>),
+    Enum,
     /// A pseudo-type.
     Pseudo,
     /// An array type along with the type of its elements.

--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -190,11 +190,9 @@ fn get_type_rec<'a>(
 
 async fn typeinfo_statement(client: &Arc<InnerClient>) -> Result<Statement, Error> {
     if let Some(stmt) = client.typeinfo() {
-        dbg!("typeinfo stmt cache hit");
         return Ok(stmt);
     }
 
-    dbg!("prepare typeinfo query");
     let stmt = match prepare_rec(client, TYPEINFO_QUERY, &[]).await {
         Ok(stmt) => stmt,
         Err(ref e) if e.code() == Some(&SqlState::UNDEFINED_TABLE) => {
@@ -203,17 +201,14 @@ async fn typeinfo_statement(client: &Arc<InnerClient>) -> Result<Statement, Erro
         Err(e) => return Err(e),
     };
 
-    dbg!(&stmt.params());
-    dbg!(&stmt.columns());
-
     client.set_typeinfo(&stmt);
     Ok(stmt)
 }
 
+#[allow(dead_code)]
 async fn get_enum_variants(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<String>, Error> {
     let stmt = typeinfo_enum_statement(client).await?;
 
-    dbg!("run enum variants query");
     query::query(client, stmt, slice_iter(&[&oid]))
         .await?
         .and_then(|row| async move { row.try_get(0) })
@@ -221,13 +216,12 @@ async fn get_enum_variants(client: &Arc<InnerClient>, oid: Oid) -> Result<Vec<St
         .await
 }
 
+#[allow(dead_code)]
 async fn typeinfo_enum_statement(client: &Arc<InnerClient>) -> Result<Statement, Error> {
     if let Some(stmt) = client.typeinfo_enum() {
-        dbg!("enum variants stmt cache hit");
         return Ok(stmt);
     }
 
-    dbg!("prepare typeinfo enum query");
     let stmt = match prepare_rec(client, TYPEINFO_ENUM_QUERY, &[]).await {
         Ok(stmt) => stmt,
         Err(ref e) if e.code() == Some(&SqlState::UNDEFINED_COLUMN) => {
@@ -235,9 +229,6 @@ async fn typeinfo_enum_statement(client: &Arc<InnerClient>) -> Result<Statement,
         }
         Err(e) => return Err(e),
     };
-
-    dbg!(&stmt.params());
-    dbg!(&stmt.columns());
 
     client.set_typeinfo_enum(&stmt);
     Ok(stmt)

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -206,14 +206,7 @@ async fn custom_enum() {
 
     let ty = &select.params()[0];
     assert_eq!("mood", ty.name());
-    assert_eq!(
-        &Kind::Enum(vec![
-            "sad".to_string(),
-            "ok".to_string(),
-            "happy".to_string(),
-        ]),
-        ty.kind(),
-    );
+    assert_eq!(&Kind::Enum, ty.kind(),);
 }
 
 #[tokio::test]

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -587,16 +587,9 @@ async fn enum_() {
 
     let stmt = client.prepare("SELECT $1::mood").await.unwrap();
     let type_ = &stmt.params()[0];
+
     assert_eq!(type_.name(), "mood");
-    match *type_.kind() {
-        Kind::Enum(ref variants) => {
-            assert_eq!(
-                variants,
-                &["sad".to_owned(), "ok".to_owned(), "happy".to_owned()]
-            );
-        }
-        _ => panic!("bad type"),
-    }
+    assert_eq!(&Kind::Enum, type_.kind());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Overview

When preparing a statement that contains query parameters, Postgres will respond back with information wrt. the type of each query parameter (if they weren't manually specified when preparing the statement).

These types are identified using an `Oid(u32)`. In the case of enum, since they are user-defined custom types, we can't know to which types these oids refer to without actually querying the database.

So, in the case of enums, tokio-postgres does the following:

1. Send a query to know to which type it refers to
2. In the case of enums, send a second query to fetch the enum's variants.

It turns out Quaint never use the variants information when serializing/deserializing enum values. Therefore, I've removed the query and data altogether.

In general, these types should be cached and fetched only once. However, in a serverless context, they keep being re-fetched all the time, which slows down queries.

This is a first step to mitigate that problem.