### PR TITLE
expose stmt name and column id and table_oid

### DIFF
--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -95,7 +95,12 @@ pub async fn prepare(
         let mut it = row_description.fields();
         while let Some(field) = it.next().map_err(Error::parse)? {
             let type_ = get_type(client, field.type_oid()).await?;
-            let column = Column::new(field.name().to_string(), type_);
+            let column = Column::new(
+                field.name().to_string(),
+                type_,
+                field.column_id(),
+                field.table_oid(),
+            );
             columns.push(column);
         }
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -49,7 +49,8 @@ impl Statement {
         }))
     }
 
-    pub(crate) fn name(&self) -> &str {
+    /// Returns the name of the statement.
+    pub fn name(&self) -> &str {
         &self.0.name
     }
 
@@ -68,11 +69,26 @@ impl Statement {
 pub struct Column {
     name: String,
     type_: Type,
+    column_id: Option<i16>,
+    table_oid: Option<u32>,
 }
 
 impl Column {
-    pub(crate) fn new(name: String, type_: Type) -> Column {
-        Column { name, type_ }
+    pub(crate) fn new(name: String, type_: Type, column_id: i16, table_oid: u32) -> Column {
+        Column {
+            name,
+            type_,
+            column_id: if column_id == 0 {
+                None
+            } else {
+                Some(column_id)
+            },
+            table_oid: if table_oid == 0 {
+                None
+            } else {
+                Some(table_oid)
+            },
+        }
     }
 
     /// Returns the name of the column.
@@ -83,6 +99,16 @@ impl Column {
     /// Returns the type of the column.
     pub fn type_(&self) -> &Type {
         &self.type_
+    }
+
+    /// Returns the id of the column if there's one.
+    pub fn column_id(&self) -> Option<i16> {
+        self.column_id
+    }
+
+    /// Returns the table_oid of the column if there's one.
+    pub fn table_oid(&self) -> Option<u32> {
+        self.table_oid
     }
 }
 


### PR DESCRIPTION
## Overview

Needed for TypedSQL to infer column nullability.

Related work:

- https://github.com/prisma/prisma-engines/pull/4979
- https://github.com/prisma/team-orm/issues/1258
